### PR TITLE
Add support for macOS Catalina

### DIFF
--- a/scripts/current_track.sh
+++ b/scripts/current_track.sh
@@ -1,19 +1,38 @@
 #!/usr/bin/env bash
 
 CURRENT_TRACK_STR=$(osascript <<EOF
-  tell application "iTunes"
-    if player state is stopped
-      return ""
-    else
-      if player state is paused then
-        set playingState to "❚❚"
-      else
-        set playingState to "▶"
-      end if
+  set _versionString to system version of (system info)
+  considering numeric strings
+    if _versionString ≥ "10.15" then
+      tell application "Music"
+        if player state is stopped then
+          return ""
+        else
+          if player state is paused then
+            set playingState to "❚❚"
+          else
+            set playingState to "▶"
+          end if
 
-      return playingState & " " & name of current track & " - " & artist of current track
+          return playingState & " " & name of current track & " - " & artist of current track
+        end if
+      end tell
+    else
+      tell application "iTunes"
+        if player state is stopped then
+          return ""
+        else
+          if player state is paused then
+            set playingState to "❚❚"
+          else
+            set playingState to "▶"
+          end if
+
+          return playingState & " " & name of current track & " - " & artist of current track
+        end if
+      end tell
     end if
-  end tell
+  end considering
 EOF)
 
 echo $CURRENT_TRACK_STR


### PR DESCRIPTION
The latest release of macOS, 10.15 Catalina, replaces the iTunes app
with a new Music app. The script needs to be updated in order to
continue working.