### PR TITLE
Add support for macOS Catalina

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,5 @@
+# 2.0 (2019-10-12)
+- Added support for macOS Catalina
+
+# 1.0 (2019-06-14)
+- Intial release and fork

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Tmux iTunes
 
-Tmux plugin that display current track name from iTunes on your status bar.
+Tmux plugin that display current track name on your status bar.
+
+Both iTunes and macOS Catalina's Music app are supported.
 
 ### Screenshot
 
@@ -20,7 +22,7 @@ Here's the example in `.tmux.conf`:
 
 Add plugin to the list of TPM plugins in `.tmux.conf`:
 
-    set -g @plugin 'aar0nTw/tmux-itunes'
+    set -g @plugin 'nick-f/tmux-itunes'
 
 Hit `prefix + I` to fetch the plugin and source it.
 

--- a/scripts/current_track_itunes_app.sh
+++ b/scripts/current_track_itunes_app.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+CURRENT_TRACK_STR=$(osascript <<EOF
+  tell application "iTunes"
+    if player state is stopped then
+      return ""
+    else
+      if player state is paused then
+        set playingState to "❚❚"
+      else
+        set playingState to "▶"
+      end if
+
+      return playingState & " " & name of current track & " - " & artist of current track
+    end if
+  end tell
+EOF)
+
+echo $CURRENT_TRACK_STR

--- a/scripts/current_track_music_app.sh
+++ b/scripts/current_track_music_app.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 
 CURRENT_TRACK_STR=$(osascript <<EOF
-  tell application "iTunes"
-    if player state is stopped
+  tell application "Music"
+    if player state is stopped then
       return ""
     else
       if player state is paused then

--- a/tmux-itunes.tmux
+++ b/tmux-itunes.tmux
@@ -2,7 +2,16 @@
 
 CURRENT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
-current_track="#($CURRENT_DIR/scripts/current_track.sh)"
+product_version=$(sw_vers -productVersion)
+os_vers=( ${product_version//./ } )
+os_vers_minor="${os_vers[1]}"
+
+if [[ ${os_vers_minor} -ge 15 ]]; then
+  current_track="#($CURRENT_DIR/scripts/current_track_music_app.sh)"
+else
+  current_track="#($CURRENT_DIR/scripts/current_track_itunes_app.sh)"
+fi
+
 current_track_interpolation="\#{current_track}"
 
 get_tmux_option() {


### PR DESCRIPTION
The latest release of macOS, 10.15 Catalina, replaces the iTunes app
with a new Music app. 

Added support for both iTunes and the Music app.